### PR TITLE
Adding authority as token property

### DIFF
--- a/src/main/java/com/daedafusion/security/authentication/Token.java
+++ b/src/main/java/com/daedafusion/security/authentication/Token.java
@@ -3,6 +3,7 @@ package com.daedafusion.security.authentication;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Created by mphilpot on 7/11/14.
@@ -21,4 +22,11 @@ public interface Token
      * @return Map
      */
     default Map<String, String> getContext(){return new HashMap<>();}
+
+    /**
+     * Token's from AuthenticatedPrincipals will have an Authority
+     *
+     * @return optional string
+     */
+    default Optional<String> getAuthority(){return Optional.empty();}
 }

--- a/src/main/java/com/daedafusion/security/authentication/TokenExchangeImpl.java
+++ b/src/main/java/com/daedafusion/security/authentication/TokenExchangeImpl.java
@@ -19,6 +19,7 @@ public class TokenExchangeImpl extends AbstractService<TokenExchangeProvider> im
     {
         Set<AuthenticatedPrincipal> aps = Arrays.stream(tokens)
                 .flatMap(token -> getProviders().stream().flatMap(tep -> tep.exchange(token).stream()))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
         if(!aps.isEmpty())
@@ -36,6 +37,7 @@ public class TokenExchangeImpl extends AbstractService<TokenExchangeProvider> im
     {
         return subject.getPrincipals().stream()
                 .flatMap(ap -> getProviders().stream().map(tep -> tep.exchange(ap)))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/daedafusion/security/authentication/impl/PrincipalToken.java
+++ b/src/main/java/com/daedafusion/security/authentication/impl/PrincipalToken.java
@@ -1,0 +1,35 @@
+package com.daedafusion.security.authentication.impl;
+
+import com.daedafusion.security.authentication.Token;
+import org.apache.log4j.Logger;
+
+import java.util.Optional;
+
+/**
+ * Created by mphilpot on 3/27/17.
+ */
+public class PrincipalToken implements Token
+{
+    private static final Logger log = Logger.getLogger(PrincipalToken.class);
+
+    private final String tokenString;
+    private final String authority;
+
+    public PrincipalToken(String tokenString, String authority)
+    {
+        this.tokenString = tokenString;
+        this.authority = authority;
+    }
+
+    @Override
+    public String getTokenString()
+    {
+        return tokenString;
+    }
+
+    @Override
+    public Optional<String> getAuthority()
+    {
+        return Optional.of(authority);
+    }
+}


### PR DESCRIPTION
When extracting tokens from Subject (and it's associated AuthenticatedPrincipals) need to keep track of the associated authority.